### PR TITLE
24 hann

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -61,9 +61,11 @@ class Product(SafeDeleteModel):
         total_rating = 0
         for rating in ratings:
             total_rating += rating.rating
-
-        avg = total_rating / len(ratings)
-        return avg
+        try:
+            avg = total_rating / len(ratings)
+            return avg
+        except ZeroDivisionError:
+            return "not applicable"
 
     class Meta:
         verbose_name = ("product")

--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -75,9 +75,9 @@ class Cart(ViewSet):
         @apiSuccess (200) {Object} payment_type Payment id use to complete order
         @apiSuccess (200) {String} customer URI for customer
         @apiSuccess (200) {Number} size Number of items in cart
-        @apiSuccess (200) {Object[]} line_items Line items in cart
-        @apiSuccess (200) {Number} line_items.id Line item id
-        @apiSuccess (200) {Object} line_items.product Product in cart
+        @apiSuccess (200) {Object[]} lineitems Line items in cart
+        @apiSuccess (200) {Number} lineitems.id Line item id
+        @apiSuccess (200) {Object} lineitems.product Product in cart
         @apiSuccessExample {json} Success
             {
                 "id": 2,

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -114,8 +114,8 @@ class Profile(ViewSet):
             try:
                 open_order = Order.objects.get(
                     customer=current_user, payment_type=None)
-                line_items = OrderProduct.objects.filter(order=open_order)
-                line_items.delete()
+                lineitems = OrderProduct.objects.filter(order=open_order)
+                lineitems.delete()
                 open_order.delete()
             except Order.DoesNotExist as ex:
                 return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
@@ -138,9 +138,9 @@ class Profile(ViewSet):
             @apiSuccess (200) {Object} payment_type Payment Id used to complete order
             @apiSuccess (200) {String} customer URI for customer
             @apiSuccess (200) {Number} size Number of items in cart
-            @apiSuccess (200) {Object[]} line_items Line items in cart
-            @apiSuccess (200) {Number} line_items.id Line item id
-            @apiSuccess (200) {Object} line_items.product Product in cart
+            @apiSuccess (200) {Object[]} lineitems Line items in cart
+            @apiSuccess (200) {Number} lineitems.id Line item id
+            @apiSuccess (200) {Object} lineitems.product Product in cart
             @apiSuccessExample {json} Success
                 {
                     "id": 2,
@@ -148,7 +148,7 @@ class Profile(ViewSet):
                     "created_date": "2019-04-12",
                     "payment_type": null,
                     "customer": "http://localhost:8000/customers/7",
-                    "line_items": [
+                    "lineitems": [
                         {
                             "id": 4,
                             "product": {
@@ -177,15 +177,15 @@ class Profile(ViewSet):
             try:
                 open_order = Order.objects.get(
                     customer=current_user, payment_type=None)
-                line_items = OrderProduct.objects.filter(order=open_order)
-                line_items = LineItemSerializer(
-                    line_items, many=True, context={'request': request})
+                lineitems = OrderProduct.objects.filter(order=open_order)
+                lineitems = LineItemSerializer(
+                    lineitems, many=True, context={'request': request})
 
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
-                cart["order"]["size"] = len(line_items.data)
+                cart["order"]["lineitems"] = lineitems.data
+                cart["order"]["size"] = len(lineitems.data)
 
             except Order.DoesNotExist as ex:
                 return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -178,9 +178,6 @@ class Profile(ViewSet):
                 open_order = Order.objects.get(
                     customer=current_user, payment_type=None)
                 lineitems = OrderProduct.objects.filter(order=open_order)
-                lineitems = LineItemSerializer(
-                    lineitems, many=True, context={'request': request})
-
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -178,10 +178,10 @@ class Profile(ViewSet):
                 open_order = Order.objects.get(
                     customer=current_user, payment_type=None)
                 lineitems = OrderProduct.objects.filter(order=open_order)
+                lineitems = LineItemSerializer(
+                    lineitems, many=True, context={'request': request})
+
                 cart = {}
-                cart["order"] = OrderSerializer(open_order, many=False, context={
-                                                'request': request}).data
-                cart["order"]["lineitems"] = lineitems.data
                 cart["order"]["size"] = len(lineitems.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
displaying incorrect key ('line_items') in profile/cart 

## Changes

- in profile.py and cart.py : changed "line_items" to "lineitems"
- removed extraneous usage of "OrderSerializer" in profile.py 

**Request**

GET `/profile/cart` gets items in cart

```json
{
    "id": 10,
    "url": "http://localhost:8000/orders/10",
    "created_date": "2018-11-03",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/4",
    "lineitems": [
        {
            "id": 2,
            "product": {
                "id": 3,
                "name": "Durango",
                "price": 541.17,
                "number_sold": 0,
                "description": "1998 Dodge",
                "quantity": 2,
                "created_date": "2019-05-16",
                "location": "Górki Wielkie",
                "image_path": null,
                "average_rating": "not applicable"
            }
        }
    ],
    "size": 1
}
```

## Testing

in postman: 

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Open PostMan workspace
- [ ] Refer to Request/Response section
- [ ] click on 'shopping cart'
- [ ] run GET 
- [ ] ensure that only 'lineitems' key returns, NOT 'line_items'


## Related Issues

- Fixes #24 